### PR TITLE
Better installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,11 @@ and has the following extensions installed:
 
 ## Installation
 
-Simply add the following to your composer.json `require-dev` field:
+Simply run the following [composer](https://getcomposer.org/) command:
 
-    "require-dev": {
-        "vectorface/dunit": "~1.0.0"
-    }
-
-and run `composer update`.
+```shell
+$ composer require vectorface/dunit --dev
+```
 
 ## Usage
 


### PR DESCRIPTION
This command will get the most stable version and pre-append a tilde.

Example:

``` shell
$ composer require vectorface/dunit --dev
Using version ~1.3 for vectorface/dunit
```
